### PR TITLE
allow newer compilers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,8 +256,8 @@ set (ALL_SRC
 	src/Base/v3d_utilities.h
 	src/Math/v3d_linear.h
 	src/Math/v3d_linearbase.h
-    src/lib/libsvflow/src/flowField_sV.h
-    src/lib/libsvflow/src/flowRW_sV.h
+    src/lib/libsvflow/include/flowField_sV.h
+    src/lib/libsvflow/include/flowRW_sV.h
 )
 
 add_library(V3D STATIC ${ALL_SRC})

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It can be used by slowmoVideo.
 On Ubuntu 20.04, install the requirements `freeglut3-dev libopencv-dev libglew-dev `
 
 ```bash
-git submodule update --init 
+git submodule update --init
 mkdir build
 cd build
 cmake ..

--- a/README.md
+++ b/README.md
@@ -10,9 +10,13 @@ It can be used by slowmoVideo.
 On Ubuntu 20.04, install the requirements `freeglut3-dev libopencv-dev libglew-dev `
 
 ```bash
-git submodule update --init
+git submodule update --init --remote
 mkdir build
 cd build
 cmake ..
 make
+
+# use compiled binary at v3d-flow-builder/build/src/slowmoFlowBuilder
+# or install:
+sudo make install
 ```

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It can be used by slowmoVideo.
 On Ubuntu 20.04, install the requirements `freeglut3-dev libopencv-dev libglew-dev `
 
 ```bash
-git submodule update --init --remote
+git submodule update --init 
 mkdir build
 cd build
 cmake ..

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-include_directories(${V3D_INCLUDE_DIRS} ${EXTRA_INC_DIRS} lib/libsvflow/src)
+include_directories(${V3D_INCLUDE_DIRS} ${EXTRA_INC_DIRS} lib/libsvflow/include)
 link_directories(${V3D_DIR} ${EXTRA_LIB_DIRS})
 link_libraries (V3D ${EXTRA_LIBRARIES})
 


### PR DESCRIPTION
See Issue #2  
It turns out the `git submodule update` wasn't getting the newest libsvflow
This required a change to the Readme instructions.
Once that was done there were a few directory issues with two CMakeLists.txt files.
No code changes were required.


Considerations for the README changes:
You might not want to pull the most recent submodule  (in the future) - I didn't research how to set the version that  the existing `git submodule update --recursive`  was retrieving.   